### PR TITLE
Update response type of text_to_speech endpoint from text to binary.

### DIFF
--- a/rhasspyclient/__init__.py
+++ b/rhasspyclient/__init__.py
@@ -189,7 +189,7 @@ class RhasspyClient:
 
     # -------------------------------------------------------------------------
 
-    async def text_to_speech(self, text: str, repeat: bool = False) -> str:
+    async def text_to_speech(self, text: str, repeat: bool = False) -> bytes:
         """
         Generate speech from text.
 

--- a/rhasspyclient/__init__.py
+++ b/rhasspyclient/__init__.py
@@ -201,7 +201,7 @@ class RhasspyClient:
             self.tts_url, params=params, data=text
         ) as response:
             response.raise_for_status()
-            return await response.text()
+            return await response.read()
 
     # -------------------------------------------------------------------------
 


### PR DESCRIPTION

I was getting tracebacks when using text_to_speech.  I found this is because rhasspy is returning binary data, and rhasspy-client was trying to utf-8 decode it (and failing). 